### PR TITLE
Multiple editor focus problem fix 

### DIFF
--- a/placeholder/plugin.js
+++ b/placeholder/plugin.js
@@ -12,7 +12,7 @@ tinymce.PluginManager.add('placeholder', function(editor) {
 
         function onFocus(){
             label.hide();
-            tinyMCE.execCommand('mceFocus', false, editor);
+            editor.execCommand('mceFocus', false);
         }
 
         function onBlur(){


### PR DESCRIPTION
Found a fix for multiple editor focus problem
it seems 
`tinyMCE.execCommand('mceFocus', false, editor);`
triggers mceFocus on all editors on screen making the focus inconsistent.

However changing it to
`editor.execCommand('mceFocus', false);`
seems to fix that problem.

BTW, I didn't compile the 'min' version.