### PR TITLE
Make tinymce-placeholder compliant to webpack/browserify with npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('tinymce/tinymce');
+require('./placeholder/plugin');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "tinymce-placeholder",
+  "version": "0.1.7",
+  "description": "TinyMCE plugin for placeholder attribute support",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mohan/tinymce-placeholder.git"
+  },
+  "keywords": [
+    "tinymce",
+    "placeholder",
+    "plugin"
+  ],
+  "author": "mohan",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mohan/tinymce-placeholder/issues"
+  },
+  "homepage": "https://github.com/mohan/tinymce-placeholder#readme",
+  "dependencies": {
+    "tinymce": "^4.4.3"
+  }
+}


### PR DESCRIPTION
Hi there!

small pr because we use your nice plugin, but we compile our assets with webpack, so we need to add them with npm.

npm init (add package.json), add index.js and .gitignore
