### PR TITLE
Fix backspace bug documented in Issue #19

### DIFF
--- a/placeholder/plugin.js
+++ b/placeholder/plugin.js
@@ -8,20 +8,26 @@ tinymce.PluginManager.add('placeholder', function(editor) {
         editor.on('focus', onFocus);
         editor.on('blur', onBlur);
         editor.on('change', onBlur);
+        editor.on('setContent', onBlur);
+        editor.on('keydown', onKeydown);
 
-        function onFocus(){
-            if(!editor.settings.readonly === true){
+        function onFocus() {
+            if (!editor.settings.readonly === true) {
                 label.hide();
             }
             editor.execCommand('mceFocus', false);
         }
 
-        function onBlur(){
-            if(editor.getContent() == '') {
+        function onBlur() {
+            if (editor.getContent() == '') {
                 label.show();
-            }else{
+            } else {
                 label.hide();
             }
+        }
+
+        function onKeydown(){
+            label.hide();
         }
     });
 

--- a/placeholder/plugin.js
+++ b/placeholder/plugin.js
@@ -8,7 +8,6 @@ tinymce.PluginManager.add('placeholder', function(editor) {
         editor.on('focus', onFocus);
         editor.on('blur', onBlur);
         editor.on('change', onBlur);
-        editor.on('setContent', onBlur);
 
         function onFocus(){
             if(!editor.settings.readonly === true){
@@ -42,6 +41,6 @@ tinymce.PluginManager.add('placeholder', function(editor) {
     }
 
     Label.prototype.show = function(){
-        tinymce.DOM.setStyle( this.el, 'display', '' );   
+        tinymce.DOM.setStyle( this.el, 'display', '' );
     }
 });

--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,44 @@ plugins: "fullscreen placeholder"
 
 Textarea:
 `<textarea class="tinymce" placeholder="Hello World!"></textarea>`
+
+Styling of the placeholder label
+--------------------------------
+
+By default, this plugin styles the placeholder with the following attributes:
+
+```js
+{
+  style: {
+    position: 'absolute',
+    top:'5px',
+    left:0,
+    color: '#888',
+    padding: '1%',
+    width:'98%',
+    overflow: 'hidden',
+    'white-space':
+    'pre-wrap'
+  }
+}
+```
+
+You can replace this styling by providing a `placeholder_attrs` section in your TinyMCE config...
+
+```js
+tinyMCE.init({
+  plugins: 'placeholder',
+  placeholder_attrs: // (new value for the above object...)
+});
+```
+
+Or alternatively, you can override these settings by providing the `!important` directive along in your CSS property for the label...
+
+```css
+.mce-edit-area {
+  label {
+    color: #A9A9A9 !important; // Override text color
+    left: 5px !important; // Override left positioning
+  }
+}
+```

--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,7 @@ By default, this plugin styles the placeholder with the following attributes:
     padding: '1%',
     width:'98%',
     overflow: 'hidden',
-    'white-space':
-    'pre-wrap'
+    'white-space': 'pre-wrap'
   }
 }
 ```
@@ -55,13 +54,13 @@ tinyMCE.init({
 });
 ```
 
-Or alternatively, you can override these settings by providing the `!important` directive along in your CSS property for the label...
+Or alternatively, you can override specific properties of the default CSS by providing the `!important` directive along in your CSS property for the label...
 
 ```css
 .mce-edit-area {
   label {
-    color: #A9A9A9 !important; // Override text color
-    left: 5px !important; // Override left positioning
+    color: #A9A9A9 !important; /* Override text color */
+    left: 5px !important; /* Override left positioning */
   }
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ plugins: "fullscreen placeholder"
 Textarea:
 `<textarea class="tinymce" placeholder="Hello World!"></textarea>`
 
-Styling of the placeholder label
+Styling the placeholder label
 --------------------------------
 
 By default, this plugin styles the placeholder with the following attributes:


### PR DESCRIPTION
Fixes https://github.com/mohan/tinymce-placeholder/issues/19

When you hit backspace repeatedly, then start typing again, the text you were
typing would overlay with the placeholder label (i.e. the placeholder label
wasn't hiding as it should).

I initially tried the approaches in #19, but I found remaining edge cases they didn't cover. Simply hiding the label on the 'keydown' event works fine.

I also updated the readme.md to provide information on styling since it's not documented.

### How to reproduce the bug this fixes

#### Versions
tinymce-placeholder-attribute 0.1.6
tinymce 4.5.1

#### Steps
1. Init TinyMCE with "placeholder" in the plugins list, add a placeholder attribute to your textarea.
1. Click into the TinyMCE box. The placeholder label disappears as expected.
1. Hit backspace, the placeholder label unexpectedly reappears.
1. Start typing, the placeholder label remains, and the text you're typing overlays with the placeholder in an ugly manner.

#### Screenshot
![cursor_and_all_questions___first_round_network](https://cloud.githubusercontent.com/assets/107841/21032236/0184d3f8-bd5d-11e6-944e-ca8bfeabc08a.png)
